### PR TITLE
Fix __init__ imports and newline

### DIFF
--- a/src/quickbooks_gui_api/__init__.py
+++ b/src/quickbooks_gui_api/__init__.py
@@ -1,7 +1,7 @@
 # src\quickbooks_gui_api\__init__.py
 
-from src.quickbooks_gui_api.gui_api import QuickBookGUIAPI
-from src.quickbooks_gui_api.setup import Setup
+from .gui_api import QuickBookGUIAPI
+from .setup import Setup
 
 __all__ = [
            "QuickBookGUIAPI",

--- a/src/quickbooks_gui_api/apis/__init__.py
+++ b/src/quickbooks_gui_api/apis/__init__.py
@@ -1,9 +1,9 @@
 # src\quickbooks_gui_api\apis\__init__.py
 
-from src.quickbooks_gui_api.apis.invoices   import Invoices
-from src.quickbooks_gui_api.apis.reports    import Reports
+from .invoices import Invoices
+from .reports import Reports
 
-from src.quickbooks_gui_api.apis.api_exceptions import ConfigFileNotFound
+from .api_exceptions import ConfigFileNotFound
 
 __all__ = [
            "Invoices",

--- a/src/quickbooks_gui_api/managers/__init__.py
+++ b/src/quickbooks_gui_api/managers/__init__.py
@@ -1,10 +1,10 @@
 # src\quickbooks_gui_api\managers\__init__.py
 
-from src.quickbooks_gui_api.managers.image      import ImageManager
-from src.quickbooks_gui_api.managers.ocr        import OCRManager
-from src.quickbooks_gui_api.managers.processes  import ProcessManager
-from src.quickbooks_gui_api.managers.windows    import WindowManager
-from src.quickbooks_gui_api.managers.string     import StringManager
+from .image import ImageManager
+from .ocr import OCRManager
+from .processes import ProcessManager
+from .windows import WindowManager
+from .string import StringManager
 
 
 __all__ = [

--- a/src/quickbooks_gui_api/models/__init__.py
+++ b/src/quickbooks_gui_api/models/__init__.py
@@ -1,9 +1,9 @@
 # src\quickbooks_gui_api\models\__init__.py
 
-from src.quickbooks_gui_api.models.invoice  import Invoice
-from src.quickbooks_gui_api.models.report   import Report
-from src.quickbooks_gui_api.models.image    import Image
-from src.quickbooks_gui_api.models.window   import Window
+from .invoice import Invoice
+from .report import Report
+from .image import Image
+from .window import Window
 
 __all__ = [
            "Invoice",


### PR DESCRIPTION
## Summary
- fix package imports to use relative paths
- add missing trailing newlines

## Testing
- `python -m py_compile src/quickbooks_gui_api/__init__.py src/quickbooks_gui_api/apis/__init__.py src/quickbooks_gui_api/managers/__init__.py src/quickbooks_gui_api/models/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_685b1a9d0cb0832093367fe81894f19e