### PR TITLE
Update imports to use package-relative paths

### DIFF
--- a/setup_cli.py
+++ b/setup_cli.py
@@ -3,7 +3,7 @@ import sys
 import logging
 from pathlib import Path
 
-from src.quickbooks_gui_api.setup import Setup  # <-- Replace with your actual module/package name
+from quickbooks_gui_api.setup import Setup
 
 def main():
     parser = argparse.ArgumentParser(

--- a/src/quickbooks_gui_api/apis/invoices.py
+++ b/src/quickbooks_gui_api/apis/invoices.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 from typing import List, Dict, Any, overload, Final
 
-from src.quickbooks_gui_api.managers import WindowManager, ImageManager, OCRManager, StringManager
-from src.quickbooks_gui_api.models import Invoice, Image, Window
+from ..managers import WindowManager, ImageManager, OCRManager, StringManager
+from ..models import Invoice, Image, Window
 
 from src.quickbooks_gui_api.apis.api_exceptions import ConfigFileNotFound, ExpectedDialogNotFound, InvalidPrinter
 

--- a/src/quickbooks_gui_api/apis/reports.py
+++ b/src/quickbooks_gui_api/apis/reports.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 from typing import List, Dict, Any, overload, Final
 
-from src.quickbooks_gui_api.managers import WindowManager, ImageManager, OCRManager, StringManager
-from src.quickbooks_gui_api.models import Report, Image, Window
+from ..managers import WindowManager, ImageManager, OCRManager, StringManager
+from ..models import Report, Image, Window
 
 from src.quickbooks_gui_api.apis.api_exceptions import ConfigFileNotFound, ExpectedDialogNotFound, InvalidPrinter
 

--- a/src/quickbooks_gui_api/gui_api.py
+++ b/src/quickbooks_gui_api/gui_api.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from typing import List, Dict, Any, overload
 
-from src.quickbooks_gui_api.managers import ImageManager, OCRManager, ProcessManager, WindowManager
+from .managers import ImageManager, OCRManager, ProcessManager, WindowManager
 
 
 

--- a/src/quickbooks_gui_api/managers/image.py
+++ b/src/quickbooks_gui_api/managers/image.py
@@ -10,7 +10,7 @@ import cv2
 
 from pathlib import Path
 
-from src.quickbooks_gui_api.models.image import Image
+from ..models import Image
 
 class Color:
     """

--- a/src/quickbooks_gui_api/managers/ocr.py
+++ b/src/quickbooks_gui_api/managers/ocr.py
@@ -10,7 +10,7 @@ import logging
 from typing import List
 from PIL import Image, ImageOps
 
-from src.quickbooks_gui_api.models import Image
+from ..models import Image
 
 class OCRManager:
     """

--- a/src/quickbooks_gui_api/managers/windows.py
+++ b/src/quickbooks_gui_api/managers/windows.py
@@ -5,7 +5,7 @@ import logging
 from pywinauto import Application, Desktop
 from typing import List, Dict, Tuple, Any, Final, overload
 
-from src.quickbooks_gui_api.models import Window
+from ..models import Window
 
 
 
@@ -158,7 +158,7 @@ class WindowManager:
             else:
                 return
         
-        raise:
+        raise RuntimeError()
 
     
 


### PR DESCRIPTION
## Summary
- use relative imports in `gui_api` and APIs
- adjust manager modules to import models with relative paths
- fix syntax error in `WindowManager.home`
- update `setup_cli` import for `Setup`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b34c333708320a5fa39b29a3a3c33