### PR TITLE
Update workflow and bump version to 1.2.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Build & Publish to PyPI
 
 on:
   release:
@@ -7,6 +7,8 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend   = "setuptools.build_meta"
 
 [project]
 name            = "qb-gui-api"
-version         = "1.2.0"
+version         = "1.2.1"
 description     = "A Python toolkit for automating QuickBooks Desktop via the GUI"
 authors         = [{ name = "Derek Banker", email = "dbb2002@gmail.com" }]
 readme          = "README.md"


### PR DESCRIPTION
Renamed the GitHub Actions workflow to 'Build & Publish to PyPI' and added write permissions for contents. Bumped the package version in pyproject.toml from 1.2.0 to 1.2.1.