### PR TITLE
Relax logger type in QuickBookGUIAPI constructor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend   = "setuptools.build_meta"
 
 [project]
 name            = "qb-gui-api"
-version         = "1.2.1"
+version         = "1.2.2"
 description     = "A Python toolkit for automating QuickBooks Desktop via the GUI"
 authors         = [{ name = "Derek Banker", email = "dbb2002@gmail.com" }]
 readme          = "README.md"

--- a/src/quickbooks_gui_api/gui_api.py
+++ b/src/quickbooks_gui_api/gui_api.py
@@ -45,7 +45,7 @@ AVATAX_PROCESSES:       list[str] = [
 class QuickBookGUIAPI:
 
     def __init__(self,
-                 logger: logging.Logger | None = None
+                 logger: Any | None = None
                  ) -> None:
         if logger is None:
             self.logger = logging.getLogger(__name__)


### PR DESCRIPTION
Changed the type hint for the logger parameter in QuickBookGUIAPI from logging.Logger to Any to allow for more flexible logger injection. Also bumped the package version to 1.2.2.