### PR TITLE
Fix logging format string in report file warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend   = "setuptools.build_meta"
 
 [project]
 name            = "qb-gui-api"
-version         = "1.3.0"
+version         = "1.3.1"
 description     = "A Python toolkit for automating QuickBooks Desktop via the GUI"
 authors         = [{ name = "Derek Banker", email = "dbb2002@gmail.com" }]
 readme          = "README.md"

--- a/src/quickbooks_gui_api/apis/reports.py
+++ b/src/quickbooks_gui_api/apis/reports.py
@@ -289,7 +289,7 @@ class Reports:
                 self.logger.debug("The report file, `%s`, is stable.", save_path.name)
                 
                 if pre_existing_file:
-                    self.logger.warning("The file `%s` existed before the report was saved. Comparing the file hashes and inspecting 'last modified' time...", save_path.name)
+                    self.logger.warning("The file `{save_path.name}` existed before the report was saved. Comparing the file hashes and inspecting 'last modified' time...")
                     hashes_match = pre_existing_file_hash == self.file_manager.hash_file(save_path)
                     time_since_modified = self.file_manager.time_since_modified(save_path)    
         


### PR DESCRIPTION
Corrected the logging format string in a warning message to use an f-string for proper variable interpolation when reporting on pre-existing report files.